### PR TITLE
Removed 14 unnecessary stubbings in ChangesSinceLastBuildMacroTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastBuildMacroTest.java
@@ -54,11 +54,9 @@ public class ChangesSinceLastBuildMacroTest {
     @Test
     public void testShouldGetChangesForLatestBuildEvenWhenPreviousBuildsExist()
             throws Exception {
-        AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
+        AbstractBuild failureBuild = createBuild2(Result.FAILURE, 41, "Changes for a failed build.");
 
         AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
-        when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
-        when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
         String content = changesSinceLastBuildMacro.evaluate(currentBuild, listener, ChangesSinceLastBuildMacro.MACRO_NAME);
 
@@ -224,11 +222,8 @@ public class ChangesSinceLastBuildMacroTest {
     
     private AbstractBuild createBuildWithAffectedFiles(Result result, int buildNumber, String message) {
         AbstractBuild build = mock(AbstractBuild.class);
-        when(build.getResult()).thenReturn(result);
         ChangeLogSet changes1 = createChangeLogWithAffectedFiles(message);
-        when(build.getChangeSet()).thenReturn(changes1);
         when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
-        when(build.getNumber()).thenReturn(buildNumber);
 
         return build;
     }
@@ -246,11 +241,8 @@ public class ChangesSinceLastBuildMacroTest {
     
     private AbstractBuild createBuildWithNoChanges(Result result, int buildNumber) {
         AbstractBuild build = mock(AbstractBuild.class);
-        when(build.getResult()).thenReturn(result);
         ChangeLogSet changes1 = createEmptyChangeLog();
-        when(build.getChangeSet()).thenReturn(changes1);
         when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
-        when(build.getNumber()).thenReturn(buildNumber);
 
         return build;
     }
@@ -258,7 +250,6 @@ public class ChangesSinceLastBuildMacroTest {
     public ChangeLogSet createEmptyChangeLog() {
         ChangeLogSet changes = mock(ChangeLogSet.class);
         List<ChangeLogSet.Entry> entries = Collections.emptyList();
-        when(changes.iterator()).thenReturn(entries.iterator());
         when(changes.isEmptySet()).thenReturn(true);
 
         return changes;
@@ -357,5 +348,20 @@ public class ChangesSinceLastBuildMacroTest {
                 }
             };
         }                
+    }
+
+    private AbstractBuild createBuild2(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog2(message);
+
+        return build;
+    }
+
+    public ChangeLogSet createChangeLog2(String message) {
+        ChangeLogSet changes = mock(ChangeLogSet.class);
+        List<ChangeLogSet.Entry> entries = new LinkedList<ChangeLogSet.Entry>();
+        ChangeLogSet.Entry entry = new ChangeLogEntry(message, "Ash Lux");
+        entries.add(entry);
+        return changes;
     }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 4 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method, `getChangeSets` method, and `getNumber` method in `ChangesSinceLastBuildMacroTest.createBuild` are created but are only executed by some of the method calls in the test `ChangesSinceLastBuildMacroTest.testShouldGetChangesForLatestBuildEvenWhenPreviousBuildsExist`

2) 3 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method, and `getNumber` method in `ChangesSinceLastBuildMacroTest.createBuildWithAffectedFiles` are created but are never executed

3) 3 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method, and `getNumber` method in `ChangesSinceLastBuildMacroTest.createBuildWithNoChanges` are created but are never executed

4) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastBuildMacroTest.createBuildWithAffectedFiles.createChangeLog` is created but is never executed by the test 'ChangesSinceLastBuildMacroTest.testShouldGetChangesForLatestBuildEvenWhenPreviousBuildsExist'

5) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastBuildMacroTest.createBuildWithAffectedFiles.createEmptyChangeLog` is created but is never executed

6) 2 unnecessary stubbings in the test `ChangesSinceLastBuildMacroTest.testShouldGetChangesForLatestBuildEvenWhenPreviousBuildsExist` are created but never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.