### PR TITLE
Removed 12 unnecessary stubbings in ChangesSinceLastUnstableBuildMacroTest.java

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
+++ b/src/test/java/org/jenkinsci/plugins/tokenmacro/impl/ChangesSinceLastUnstableBuildMacroTest.java
@@ -59,7 +59,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
             throws Exception {
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -82,10 +82,9 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
-        when(failureBuild.getNextBuild()).thenReturn(currentBuild);
-
+        
         String contentStr = content.evaluate(currentBuild, listener, ChangesSinceLastUnstableBuildMacro.MACRO_NAME);
 
         assertEquals("Changes for Build #42\n" + "[Ash Lux] Changes for a successful build.\n" + "\n" + "\n"
@@ -97,15 +96,12 @@ public class ChangesSinceLastUnstableBuildMacroTest {
             throws Exception {
         // Test for HUDSON-3519
 
-        AbstractBuild successfulBuild = createBuild(Result.SUCCESS, 2, "Changes for a successful build.");
+        AbstractBuild successfulBuild = createBuild3(Result.SUCCESS, 2, "Changes for a successful build.");
 
-        AbstractBuild unstableBuild = createBuild(Result.UNSTABLE, 3, "Changes for an unstable build.");
-        when(unstableBuild.getPreviousBuild()).thenReturn(successfulBuild);
-        when(successfulBuild.getNextBuild()).thenReturn(unstableBuild);
+        AbstractBuild unstableBuild = createBuild2(Result.UNSTABLE, 3, "Changes for an unstable build.");
 
         AbstractBuild abortedBuild = createBuild(Result.ABORTED, 4, "Changes for an aborted build.");
         when(abortedBuild.getPreviousBuild()).thenReturn(unstableBuild);
-        when(unstableBuild.getNextBuild()).thenReturn(abortedBuild);
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 5, "Changes for a failed build.");
         when(failureBuild.getPreviousBuild()).thenReturn(abortedBuild);
@@ -115,7 +111,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
         when(notBuiltBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(notBuiltBuild);
 
-        AbstractBuild currentBuild = createBuild(Result.UNSTABLE, 7, "Changes for an unstable build.");
+        AbstractBuild currentBuild = createBuild4(Result.UNSTABLE, 7, "Changes for an unstable build.");
         when(currentBuild.getPreviousBuild()).thenReturn(notBuiltBuild);
         when(notBuiltBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -147,7 +143,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -166,7 +162,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -182,7 +178,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -199,7 +195,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "Changes for a failed build.");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "Changes for a successful build.");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "Changes for a successful build.");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -219,7 +215,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
 
         AbstractBuild failureBuild = createBuild(Result.FAILURE, 41, "<defectId>DEFECT-666</defectId><message>Changes for a failed build.</message>");
 
-        AbstractBuild currentBuild = createBuild(Result.SUCCESS, 42, "<defectId>DEFECT-666</defectId><message>Changes for a successful build.</message>");
+        AbstractBuild currentBuild = createBuild4(Result.SUCCESS, 42, "<defectId>DEFECT-666</defectId><message>Changes for a successful build.</message>");
         when(currentBuild.getPreviousBuild()).thenReturn(failureBuild);
         when(failureBuild.getNextBuild()).thenReturn(currentBuild);
 
@@ -321,9 +317,7 @@ public class ChangesSinceLastUnstableBuildMacroTest {
     
     private AbstractBuild createBuildWithNoChanges(Result result, int buildNumber) {
         AbstractBuild build = mock(AbstractBuild.class);
-        when(build.getResult()).thenReturn(result);
         ChangeLogSet changes1 = createEmptyChangeLog();
-        when(build.getChangeSet()).thenReturn(changes1);
         when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
         when(build.getNumber()).thenReturn(buildNumber);
 
@@ -333,7 +327,6 @@ public class ChangesSinceLastUnstableBuildMacroTest {
     public ChangeLogSet createEmptyChangeLog() {
         ChangeLogSet changes = mock(ChangeLogSet.class);
         List<ChangeLogSet.Entry> entries = Collections.emptyList();
-        when(changes.iterator()).thenReturn(entries.iterator());
         when(changes.isEmptySet()).thenReturn(true);
 
         return changes;
@@ -405,5 +398,34 @@ public class ChangesSinceLastUnstableBuildMacroTest {
             // 10/21/13 7:39 PM
             return 1382409540000L;
         }
+    }
+
+    private AbstractBuild createBuild2(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog2(message);
+        when(build.getResult()).thenReturn(result);
+        return build;
+    }
+
+    private AbstractBuild createBuild3(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog2(message);
+        return build;
+    }
+
+    private AbstractBuild createBuild4(Result result, int buildNumber, String message) {
+        AbstractBuild build = mock(AbstractBuild.class);
+        ChangeLogSet changes1 = createChangeLog(message);
+        when(build.getChangeSets()).thenReturn(Collections.singletonList(changes1));
+        when(build.getNumber()).thenReturn(buildNumber);
+        return build;
+    }
+
+    public ChangeLogSet createChangeLog2(String message) {
+        ChangeLogSet changes = mock(ChangeLogSet.class);
+        List<ChangeLogSet.Entry> entries = new LinkedList<ChangeLogSet.Entry>();
+        ChangeLogSet.Entry entry = new ChangeLogEntry(message, "Ash Lux");
+        entries.add(entry);
+        return changes;
     }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 
1)  3 unnecessary stubbings which stubbed `getChangeSet` method, `getChangeSets` method, and `getNumber` method in `ChangesSinceLastUnstableBuildMacroTest.createBuild` are created but are only executed by some of the method calls in the test `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`

2)  4 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method, `getChangeSets` method, and `getNumber` method in `ChangesSinceLastUnstableBuildMacroTest.createBuild` are created but are not executed by the test `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`

3) 2 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method in `ChangesSinceLastUnstableBuildMacroTest.createBuildWithAffectedFiles` are created but are are only executed by some of the method calls in 8 tests: `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildFailures`, `ChangesSinceLastUnstableBuildMacroTest.testGetContent_whenReverseOrderIsTrueShouldReverseOrderOfChanges`, `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`, `ChangesSinceLastUnstableBuildMacroTest.testShouldPrintDate`,
`ChangesSinceLastUnstableBuildMacroTest.testShouldPrintRevision`, `ChangesSinceLastUnstableBuildMacroTest.testShouldPrintPath`,
`ChangesSinceLastUnstableBuildMacroTest.testWhenShowPathsIsTrueShouldPrintPath`, `ChangesSinceLastUnstableBuildMacroTest.testRegexReplace`;

4) 1 unnecessary stubbings which stubbed `getResult` method, `getChangeSet` method in `ChangesSinceLastUnstableBuildMacroTest.createBuildWithNoChanges` are created but are never executed.

5) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastUnstableBuildMacroTest.createChangeLog` is created but is only executed by some specific method calls in the test `ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519`

6) 1 unnecessary stubbing which stubbed `iterator` method in `ChangesSinceLastUnstableBuildMacroTest.createBuildWithAffectedFiles.createEmptyChangeLog` is created but is never executed.

7) 3 unnecessary stubbings in the test 'ChangesSinceLastUnstableBuildMacroTest.testGetContent_shouldGetPreviousBuildsThatArentUnstable_HUDSON3519' are created but are never executed.

8) 1 unnecessary stubbing in the test 'ChangesSinceLastUnstableBuildMacroTest. whenReverseOrderIsTrueShouldReverseOrderOfChanges' is created but is never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.